### PR TITLE
use the latest version of minikerberos

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
 	# long_description=open("README.txt").read(),
 	python_requires='>=3.6',
 	install_requires=[
-		'minikerberos>=0.2.0',
+		'minikerberos>=0.3.1',
 	],
 	
 	classifiers=(


### PR DESCRIPTION
0.3.x have brought some breaking changes by removing some files

https://github.com/skelsec/minikerberos/commit/b3b22a61c82a915bbd92ef51cd0d8249b8db2c38

would be better that all CME sub-dependencies use 0.3.1 to avoid

```
ModuleNotFoundError: No module named 'minikerberos.network.aioclientsockssocket'
```

because some sub-dependencies of CME still use minikerberos 0.2.x